### PR TITLE
feat/Improve Set Service 

### DIFF
--- a/injector.go
+++ b/injector.go
@@ -227,12 +227,10 @@ func (i *Injector) get(name string) (any, bool) {
 
 func (i *Injector) set(name string, service any) {
 	i.mu.Lock()
-	defer i.mu.Unlock()
-
 	i.services[name] = service
+	i.mu.Unlock()
 
-	// defering hook call will unlock mutex
-	defer i.onServiceRegistration(name)
+	i.onServiceRegistration(name)
 }
 
 func (i *Injector) remove(name string) {


### PR DESCRIPTION
Defer is last in, first out, thus defer directly before return makes no sense. This should improve current mutex logic. 